### PR TITLE
Improvement on installation process

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Che4z is powered by the open-source projects [Eclipse Che](https://www.eclipse.o
 
 ## Getting Started
 
-Before you start using Che4z, ensure you have access to an instance of Eclipse Che.
+Before you start using Che4z, ensure you have access to an instance of Eclipse Che. 
 
 ### Launch the Basic Stack
 
@@ -25,7 +25,7 @@ A workspace is created with Eclipse Che4z extensions available.
 
 ### Launch the Premium Stack
 
-To install the Che4z [premium stack](https://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-mainframe-software/devops/ca-brightside/3-0/eclipse-che4z.html), **follow these steps**: 
+The Che4z [premium stack](https://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-mainframe-software/devops/ca-brightside/3-0/eclipse-che4z.html) is distributed as part of CA Brightside. To install the Che4z premium stack, **follow these steps**: 
 
 1. Log in to Eclipse Che.
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ A workspace is created with Eclipse Che4z extensions available.
 
 ### Check Extension Requirements
 
-After you launch your stack, ensure you meet the prerequisites of the individual extensions that you want to use. Explorer for Endevor requires access to CA Endevor® SCM, and Debugger for Mainframe requires access to CA InterTest™ for CICS. To find out more about each extension's requirements, click the headers below to navigate to their user documentation.
+After you launch your stack, ensure you meet the prerequisites of the individual extensions that you want to use. Explorer for Endevor requires access to CA Endevor® SCM, and Debugger for Mainframe requires access to CA InterTest™ for CICS. To find out more about each extension's requirements, click the headers below to navigate to their user documentation spaces.
 
 ## Extensions
 

--- a/README.md
+++ b/README.md
@@ -6,14 +6,24 @@ Che4z offers mainframe application developers a modern, familiar and seamless ex
 
 Che4z is powered by the open-source projects [Eclipse Che](https://www.eclipse.org/che/docs/che-7) and [Zowe](https://www.zowe.org/). Many of these extensions, and other mainframe-oriented innovations, are also available as part of the Code4z package of extensions for Visual Studio Code. 
 
-## Installing Che4z
+## Getting Started
 
+Before you start using Che4z, ensure you have access to an instance of Eclipse Che.
 
-### Basic Stack
+### Launch the Basic Stack
 
-The Che4z basic stack is included with Eclipse Che version 7.6.0 and above, so no installation is necessary. To get started, create a new workspace and select the **Mainframe Basic Stack**.
+The Che4z basic stack is included with Eclipse Che version 7.6.0 and above, so no installation is necessary. To get started, **follow these steps:** 
 
-### Premium Stack
+1. Log in to Eclipse Che.
+
+2. In **Workspaces**, click **Add Workspace**.
+
+3. Under **Select Stack**, select the **Mainframe Basic Stack**.
+
+4. Click **Create & Open** and wait for the workspace to initialize.  
+A workspace is created with Eclipse Che4z extensions available.
+
+### Launch the Premium Stack
 
 To install the Che4z [premium stack](https://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-mainframe-software/devops/ca-brightside/3-0/eclipse-che4z.html), **follow these steps**: 
 
@@ -29,6 +39,10 @@ To install the Che4z [premium stack](https://techdocs.broadcom.com/content/broad
     
 6. Click **Create & Open** and wait for the workspace to initialize.  
 A workspace is created with Eclipse Che4z extensions available.
+
+### Check Extension Prerequisites
+
+After you launch your stack, ensure you meet the prerequisites of the individual extensions that you want to use. To find out more about each extension's requirements, click the headers below to navigate to their user documentation.
 
 ## Extensions
 

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ To install the Che4z [premium stack](https://techdocs.broadcom.com/content/broad
 6. Click **Create & Open** and wait for the workspace to initialize.  
 A workspace is created with Eclipse Che4z extensions available.
 
-### Check Extension Prerequisites
+### Check Extension Requirements
 
-After you launch your stack, ensure you meet the prerequisites of the individual extensions that you want to use. Explorer for Endevor requires access to CA Endevor SCM, and Debugger for Mainframe requires access to CA InterTest for CICS. To find out more about each extension's requirements, click the headers below to navigate to their user documentation.
+After you launch your stack, ensure you meet the prerequisites of the individual extensions that you want to use. Explorer for Endevor requires access to CA Endevor® SCM, and Debugger for Mainframe requires access to CA InterTest™ for CICS. To find out more about each extension's requirements, click the headers below to navigate to their user documentation.
 
 ## Extensions
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ A workspace is created with Eclipse Che4z extensions available.
 
 ### Check Extension Prerequisites
 
-After you launch your stack, ensure you meet the prerequisites of the individual extensions that you want to use. To find out more about each extension's requirements, click the headers below to navigate to their user documentation.
+After you launch your stack, ensure you meet the prerequisites of the individual extensions that you want to use. Explorer for Endevor requires access to CA Endevor SCM, and Debugger for Mainframe requires access to CA InterTest for CICS. To find out more about each extension's requirements, click the headers below to navigate to their user documentation.
 
 ## Extensions
 


### PR DESCRIPTION
I've beefed out the installation procedures a bit, there was a step missing from the premium stack one and the basic stack one looks better as steps than as one sentence, 

I also added a section basically advising the user to check prerequisites, and mentioning the two most important which are that DAP and E4E won't work without InterTest and Endevor. I am not sure whether to add something there about zosmf profiles, because you can create one of those while setting up the connection to Zowe Explorer.

Let me know what you think