### PR TITLE
fix: exclude cypressEnv.ts file

### DIFF
--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -13,5 +13,5 @@
     "types": ["cypress"]
   },
   "include": ["src/**/*.ts", "./node_modules/cypress"],
-  "exclude": ["dist", "node_modules"]
+  "exclude": ["dist", "node_modules", "src/cypressEnv.ts"]
 }


### PR DESCRIPTION
We don't need to transpile to JavaScript `cypressEnv.ts`

 Signed-off-by: Maryna Nalbandian <maryna.nalbandian@broadcom.com>