### PR TITLE
Fix empty generated debug* and flow* files. 

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -22,10 +22,12 @@
     "yarn-lockfile": "^1.1.1"
   },
   "devDependencies": {
+    "@types/node": "^14.14.28",
     "@typescript-eslint/eslint-plugin": "^4.5.0",
     "@typescript-eslint/parser": "^4.5.0",
     "cypress": "6.4.0",
     "cypress-iframe": "^1.0.1",
+    "cypress-xpath": "^1.6.2",
     "eslint": "^7.11.0",
     "eslint-config-prettier": "^6.14.0",
     "eslint-plugin-cypress": "^2.11.2",

--- a/tests/src/debug.ts
+++ b/tests/src/debug.ts
@@ -17,10 +17,10 @@
 
 /// <reference types="cypress" />
 
-import { USER, PASS, CICSAPPLID, INTERTESTPORT, CONVJCL, ORIGJCL } from './cypressEnv';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { USER, PASS, CICSAPPLID, INTERTESTPORT, CONVJCL, ORIGJCL } = require('./cypressEnv');
 
-//@ts-ignore
-const rawTypeString = (str) => str.replace(/{/g, '{{}'); // Types the literal { key
+const rawTypeString = (str: string) => str.replace(/{/g, '{{}'); // Types the literal { key
 
 declare namespace Cypress {
   interface Chainable<Subject> {

--- a/tests/src/flow.ts
+++ b/tests/src/flow.ts
@@ -16,8 +16,8 @@
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference types="cypress-iframe" />
 
-import 'cypress-iframe';
-import 'cypress-xpath';
+require('cypress-iframe');
+require('cypress-xpath');
 
 /* eslint-disable @typescript-eslint/no-namespace */
 
@@ -89,6 +89,7 @@ Cypress.Commands.add('generateAndClickCobolControlFlow', (filename: string, para
   cy.get('.theia-notification-list').contains(`Loading control flow of ${filename}`);
   //@ts-ignore
   cy.loadFlowIframe()
+    //@ts-ignore
     .xpath('//*[name()="svg"][@class="svg-chart-container"]')
     .click()
     .xpath(xpath_paragraph + '/../..')

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -10,7 +10,7 @@
     "outDir": "dist",
     "target": "ES6",
     "lib": ["ES6", "DOM"],
-    "types": ["cypress"]
+    "types": ["cypress", "node"]
   },
   "include": ["src/**/*.ts", "./node_modules/cypress"],
   "exclude": ["dist", "node_modules"]

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -116,6 +116,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
   integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
 
+"@types/node@^14.14.28":
+  version "14.14.28"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.28.tgz#cade4b64f8438f588951a6b35843ce536853f25b"
+  integrity sha512-lg55ArB+ZiHHbBBttLpzD07akz0QPrZgUODNakeC09i62dnrywr9mFErHuaPlB6I7z+sEbK+IYmplahvplCj2g==
+
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
@@ -616,6 +621,11 @@ cypress-iframe@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cypress-iframe/-/cypress-iframe-1.0.1.tgz#2a286cfd47a240aa9af0ad9f339f4c6f942089f8"
   integrity sha512-Ne+xkZmWMhfq3x6wbfzK/SzsVTCrJru3R3cLXsoSAZyfUtJDamXyaIieHXeea3pQDXF4wE2w4iUuvCYHhoD31g==
+
+cypress-xpath@^1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/cypress-xpath/-/cypress-xpath-1.6.2.tgz#e9d44c3ab694fefa8608f1d977e3e389647f10d3"
+  integrity sha512-mtwJPl840GQPGtb480fKR5vDIcijBHhAVwby5/AIPIT/UVT7UJhM2L42/R+venR7N01I0PoOJErb6UiMbCyUxg==
 
 cypress@6.4.0:
   version "6.4.0"


### PR DESCRIPTION
This PR fixes problems with transpiling ts -> js. The problem was in files `debug.ts` and `flow.ts`, files weren't transpiled(there were empty `*.d.ts` and contained `export {}`). That's because the files contain an import option.  `tsc` will not emit code if the target is `CommonJS`. I decided to leave it as it is but add `@types/node instead`. 

## How to test
1. Run `tsc --build tsconfig.json`
2. Open `node_modules/@eclipse/che-che4z/tests/dist` folder. 
3. Find `debug.d.ts` and `flow.d.ts`. Open them.

**Expected result**: they are not empty and you can see declared functions. 

Signed-off-by: Maryna Nalbandian <maryna.nalbandian@broadcom.com>