### PR TITLE
test: refactor hostname extraction

### DIFF
--- a/tests/src/symdump.ts
+++ b/tests/src/symdump.ts
@@ -25,7 +25,12 @@ const {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
 } = require('./cypressEnv');
 
-const { hostname } = new URL(SYMDUMPHOST);
+// eslint-disable-next-line no-useless-escape
+const pattern = /(.+:\/\/)?([^\/]+)(\/.*)*/i;
+const url = SYMDUMPHOST;
+const arr = pattern.exec(url);
+//@ts-ignore
+const hostname = arr[2];
 
 declare namespace Cypress {
   interface Chainable<Subject> {


### PR DESCRIPTION
`symdump.ts` was affecting COBOL LS (we don't use there `as-a`). 
Tested with symdump and with COBOL LS -> worked for me. 

Signed-off-by: Maryna Nalbandian <maryna.nalbandian@broadcom.com>