### PR TITLE
Update installation procedure for premium stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,17 @@ The Che4z basic stack is included with Eclipse Che version 7.6.0 and above, so n
 
 To install the Che4z [premium stack](https://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-mainframe-software/devops/ca-brightside/3-0/eclipse-che4z.html), **follow these steps**: 
 
-1. Log in to Eclipse Che.
+1. Open a ticket with [Broadcom Support](https://casupport.broadcom.com) to obtain the URL of the Che4z premium stack devfile.
 
-2. In **Workspaces**, click **Import Devfile**.
+2. Log in to Eclipse Che.
 
-3. Next to **Source**, select **URL**.
+3. In **Workspaces**, click **Import Devfile**.
 
-4. In the **URL** field, paste the Eclipse Che4z premium stack URL, which is specified in the CA Brightside PDF installation guide available from [Broadcom Support](https://casupport.broadcom.com/download-center/download-center.html). For more information, see the **Getting Started** section in the [CA Brightside documentation](https://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-mainframe-software/devops/ca-brightside/3-0/getting-started.html).
+4. Next to **Source**, select **URL**.
+
+5. In the **URL** field, paste the Eclipse Che4z premium stack devfile URL.
     
-5. Click **Create & Open** and wait for the workspace to initialize.  
+6. Click **Create & Open** and wait for the workspace to initialize.  
 A workspace is created with Eclipse Che4z extensions available.
 
 ## Extensions

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ The Che4z basic stack is included with Eclipse Che version 7.6.0 and above, so n
 
 To install the Che4z [premium stack](https://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-mainframe-software/devops/ca-brightside/3-0/eclipse-che4z.html), **follow these steps**: 
 
-1. Open a ticket with [Broadcom Support](https://casupport.broadcom.com) to obtain the URL of the Che4z premium stack devfile.
+1. Open a [CA Brightside Support Ticket](https://support.broadcom.com/mainframe-software/product-page.html?productName=CA%20Brightside) to obtain the devfile URL for the Che4z premium stack.
 
-2. Log in to Eclipse Che.
+2. Once you receive the URL, log in to Eclipse Che.
 
 3. In **Workspaces**, click **Import Devfile**.
 


### PR DESCRIPTION
The installation procedure for the Premium stack needed updating 
- the Installation PDF containing the devfile URL was removed for "UX reasons". Discussions about readding it seem to have stopped so for the time being, I am changing our advice to the user to contact support, which is currently the only way to get the premium stack devfile URL
- more minor changes to account for changes to the Che interface.